### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ inspire by [Lepture's Editor](http://lab.lepture.com/editor/)
 
 一个有情怀的编辑器。Bach's Editor.
 
-##开发者使用方法##
+## 开发者使用方法 ##
 - 安装 component
 ```
 npm install -g component


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
